### PR TITLE
Fix wrapper script indentation issue with systemd

### DIFF
--- a/lib/capistrano/tasks/asdf.rake
+++ b/lib/capistrano/tasks/asdf.rake
@@ -5,12 +5,12 @@ ASDF_DEFAULT_RUBY_BINS = %w{rake gem bundle ruby rails}
 # Nodejs related bin
 ASDF_DEFAULT_NODEJS_BINS = %w{node npm yarn}
 
-ASDF_DEFAULT_WRAPPER_TEMPALTES = %{
+ASDF_DEFAULT_WRAPPER_TEMPALTES = <<~HEREDOC
   #!/usr/bin/env bash
 
   . @@ASDF_USER_PATH@@/asdf.sh
   exec "$@"
-}
+HEREDOC
 
 namespace :asdf do
   desc "Upload ASDF wrapper to the target host"


### PR DESCRIPTION
When using this wrapper with Systemd it results in an Exec format error.

This is due to the fact the script currently has all the lines indented with 2 chars, 
so Systemd can't determine this is a bash script.

Using a Squiggly Heredoc fixes this.